### PR TITLE
Use UNRECOGNIZED enum value when value unknown

### DIFF
--- a/java/core/src/main/java/com/google/protobuf/Descriptors.java
+++ b/java/core/src/main/java/com/google/protobuf/Descriptors.java
@@ -1595,6 +1595,23 @@ public final class Descriptors {
       if (result != null) {
         return result;
       }
+
+      return createEnumValueDescriptor(number);
+    }
+
+    /**
+     * Create the UNRECOGNIZED enum value descriptor by using a number outside the range of valid
+     * numbers.
+     */
+    public EnumValueDescriptor createUnrecognizedValueDescriptor() {
+      return createEnumValueDescriptor(-1);
+    }
+
+    /**
+     * Construct an EnumValueDescriptor for a number.
+     */
+    private EnumValueDescriptor createEnumValueDescriptor(final int number) {
+      EnumValueDescriptor result = null;
       // The number represents an unknown enum value.
       synchronized (this) {
         // Descriptors are compared by object identity so for the same number

--- a/java/util/src/test/java/com/google/protobuf/util/JsonFormatTest.java
+++ b/java/util/src/test/java/com/google/protobuf/util/JsonFormatTest.java
@@ -1160,6 +1160,13 @@ public class JsonFormatTest extends TestCase {
     }
   }
 
+  public void testParserUsingUnrecognizedEnumValues() throws Exception {
+    TestAllTypes.Builder builder = TestAllTypes.newBuilder();
+    String json = "{\n" + "  \"optionalNestedEnum\": \"XXX\"\n" + "}";
+    JsonFormat.parser().usingUnrecognizedEnumValue().merge(json, builder);
+    assertEquals(NestedEnum.UNRECOGNIZED, builder.getOptionalNestedEnum());
+  }
+
   public void testParserIgnoringUnknownFields() throws Exception {
     TestAllTypes.Builder builder = TestAllTypes.newBuilder();
     String json = "{\n" + "  \"unknownField\": \"XXX\"\n" + "}";


### PR DESCRIPTION
Rather than throwing an invalid protocol buffer exception when an enum value is unknown, use the UNRECOGNIZED enum value.

Signed-off-by: Veeren Mandalia <veeren@postmates.com>